### PR TITLE
Fix healthcheck directive in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Create directories for loading sql dumps
-# Note: for importing built-in data, we are using the /initialize folder, because when mapping the 
+# Note: for importing built-in data, we are using the /initialize folder, because when mapping the
 # /data folder to host, its contents get emptied
 RUN mkdir -p /initialize
 RUN mkdir -p /data
@@ -25,8 +25,8 @@ COPY ./scripts /usr/src/app/scripts
 # Entrypoint for loading sql dumps and starting the mssql server
 CMD /bin/bash ./scripts/entrypoint.sh
 
-HEALTHCHECK --interval=1m --timeout=5s \
-    CMD exec 3<>/dev/tcp/localhost/1443
+HEALTHCHECK --interval=5s --timeout=5s --start-period=20s --retries=20 \
+    CMD /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -Q "SELECT 1"
 
 # extends the :empty image and copies the init data to the /initialize folder
 # from which the entrypoint automatically load it


### PR DESCRIPTION
The exec 3<>/dev/tcp does not work in windows docker images

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-mssql-testdb/3)
<!-- Reviewable:end -->
