### PR TITLE
Increase timeouts when starting up the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY ./scripts /usr/src/app/scripts
 # Entrypoint for loading sql dumps and starting the mssql server
 CMD /bin/bash ./scripts/entrypoint.sh
 
-HEALTHCHECK --interval=5s --timeout=5s --start-period=20s --retries=20 \
+HEALTHCHECK --interval=5s --timeout=5s --start-period=30s --retries=30 \
     CMD /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -Q "SELECT 1"
 
 # extends the :empty image and copies the init data to the /initialize folder

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -20,7 +20,7 @@ function import_from_folder {
 
 function wait_and_populate {
     echo "Waiting for MSSQL to start..."
-    /usr/src/app/scripts/wait-for-it.sh --host=localhost --port=1433 --timeout=30
+    /usr/src/app/scripts/wait-for-it.sh --host=localhost --port=1433 --timeout=120
 
     # We must wait a few additional seconds, otherwise login might fail
     # with "Error: 18456, Severity: 14, State: 7."


### PR DESCRIPTION
When running many docker containers at once, the service takes additional time to start up and fails if we don't give it enough time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-mssql-testdb/4)
<!-- Reviewable:end -->
